### PR TITLE
Divert nagios Zephyr messages to scripts-spew channel

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -138,14 +138,12 @@ func (b *Bridge) Run(ctx context.Context) error {
 				return err
 			}
 			altChannels := map[string]*model.Channel{}
-			if mapping.Diversions != nil {
-				for user, channelName := range mapping.Diversions {
-					altChannel, err := bot.AttachChannel(channelName)
-					if err != nil {
-						return err
-					}
-					altChannels[user] = altChannel
+			for user, channelName := range mapping.Diversions {
+				altChannel, err := bot.AttachChannel(channelName)
+				if err != nil {
+					return err
 				}
+				altChannels[user] = altChannel
 			}
 			eg.Go(func() error {
 				for message := range zgramCh {

--- a/config.yml
+++ b/config.yml
@@ -96,6 +96,8 @@ mappings:
   class: mirrors
 - channel: scripts
   class: scripts
+  diversions:
+    nagios: scripts-spew
 - channel: test
   class: mattermost-test
 - channel: xvm


### PR DESCRIPTION
As discussed on Mattermost, the current situation with the 'nagios' user in the Scripts channel is making it extremely difficult for me to follow along with conversation in that channel.

This proposed change adds a feature to redirect particular users' Zephyr messages to particular channels, and uses it to redirect messages for the 'nagios' user. This way, people reading messages on Mattermost will be able to opt in and out of the separate high-volume channel. The decision to make this operate on a user-by-user basis is so that human replies to the automated messages will always show up in the regular channel, where it can be assured that they will be seen. (Redirecting these messages to the high-volume channel would make it very likely that they are never seen.)

Currently, no messages can flow the other direction from the diversion target channel; there will need to be a warning added to the channel header so that nobody thinks they can reply there and have it seen. Also, the 'scripts-spew' channel named here does not actually exist yet, so let me know before you redeploy the server so that I can actually finish making it.

While hiding monitoring spew is not the optimal solution to monitoring spew, fixing that problem is a larger job, and this palliative change is worthwhile in the meantime.

Please let me know whether you have any problems with this proposal.