### PR TITLE
Don't double-bridge Matrix messages

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -147,7 +147,10 @@ func (b *Bridge) Run(ctx context.Context) error {
 			}
 			eg.Go(func() error {
 				for message := range zgramCh {
-					if message.Header.OpCode == "mattermost" {
+					// Messages with opcode "matrix" come from the Matrix->Zephyr pathway,
+					// and we don't want to double-bridge them, since they are already bridged
+					// by the Matrix->Mattermost pathway
+					if message.Header.OpCode == "mattermost" || message.Header.OpCode == "matrix" {
 						continue
 					}
 					logMessage(message)


### PR DESCRIPTION
Since mm2zephyr currently has no awareness of other bridges potentially coexisting with it, when adding the [upcoming bridge with Matrix](https://github.com/sipb/matrix-zephyr-bridge/), messages are sent twice.

This PR makes mm2zephyr check if messages were sent by a Matrix bridge before bridging them.